### PR TITLE
feat: working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ dist
 
 # Cache
 .eslintcache
+
+.idea

--- a/src/utils/detect-package-manager.ts
+++ b/src/utils/detect-package-manager.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs/promises';
+import path from "node:path";
+import {access} from "node:fs";
 
-export const detectPackageManager = () => Promise.any([
-	fs.access('package-lock.json').then(() => 'npm'),
-	fs.access('yarn.lock').then(() => 'yarn'),
-	fs.access('pnpm-lock.yaml').then(() => 'pnpm'),
-	fs.access('bun.lockb').then(() => 'bun'),
+export const detectPackageManager = (cwd: string) => Promise.any([
+	fs.access(path.join(cwd, 'package-lock.json')).then(() => 'npm'),
+	fs.access(path.join(cwd, 'yarn.lock')).then(() => 'yarn'),
+	fs.access(path.join(cwd, 'pnpm-lock.yaml')).then(() => 'pnpm'),
+	fs.access(path.join(cwd, 'bun.lockb')).then(() => 'bun'),
 ]);


### PR DESCRIPTION
Add directory flag to set the working directory and use it as base for the publish

e.g: if `--directory packages/my-package` the command will search for the package.json in that folder and the file `packages/my-package/my-folder/my-file` become `my-folder/my-file` in the publish branch