### PR TITLE
feat: support publishing packages from monorepos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ node_modules/
 .vscode
 
 # Distribution
-dist
+/dist
 
 # Cache
 .eslintcache

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ Yes, if using a Git client authorized to access the private repository.
 
 If it must be publicly accessible, you can set the `--remote <remote>` flag to push the publish assets to a public repository. It's recommended to compile and minify the code if doing this with private code.
 
+### Can I publish a package from a monorepo?
+
+Yes, just run `git-publish` from inside the package directory you want to publish (e.g. `packages/my-lib`). It will detect that package's `package.json` and publish its contents to the root of the published Git branch.
+
+However, be aware that it doesn't currently resolve `workspace:` protocol dependencies, so you'll need to avoid or pre-resolve those if you're using them.
 
 #### User story
 You want to test a branch on a private repository _Repo A_, but GitHub Actions on the consuming project _Repo B_ doesn't have access to the private repository so `npm install` fails.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,8 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
 
+  tests/monorepo-fixture: {}
+
 packages:
 
   '@babel/code-frame@7.27.1':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - tests/monorepo-fixture

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,18 +260,18 @@ const { stringify } = JSON;
 						await Promise.all(
 							publishFiles.map(async (file) => {
 								const sourceFile = path.join(workingDirectory, file);
-								const destFile = path.join(worktreePath, file);
-								await fs.mkdir(path.dirname(destFile), { recursive: true });
+								const destinationFile = path.join(worktreePath, file);
+								await fs.mkdir(path.dirname(destinationFile), { recursive: true });
 
 								try {
-									await fs.rm(destFile, { force: true });
+									await fs.rm(destinationFile, { force: true });
 								} catch {}
 
-								await fs.rename(sourceFile, destFile);
+								await fs.rename(sourceFile, destinationFile);
 							}),
 						);
 					}
-					
+
 					await spawn('git', ['add', '-f', ...publishFiles], { cwd: worktreePath });
 
 					const trackedFiles = await gitStatusTracked({ cwd: worktreePath });

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,11 +79,20 @@ const { stringify } = JSON;
 	}
 
 	const {
-		branch: publishBranch = `npm/${currentBranch}`,
+		branch,
 		remote,
 		fresh,
 		dry,
 	} = argv.flags;
+
+	let publishBranch = branch;
+	if (!publishBranch) {
+		let defaultBranchName = `npm/${currentBranch}`;
+		if (gitSubdirectory) {
+			defaultBranchName += `-${packageJson.name}`;
+		}
+		publishBranch = defaultBranchName;
+	}
 
 	await task(
 		`Publishing branch ${stringify(currentBranch)} → ${stringify(publishBranch)}`,
@@ -266,6 +275,7 @@ const { stringify } = JSON;
 					);
 					const totalSize = fileSizes.reduce((accumulator, { size }) => accumulator + size, 0);
 
+					console.log(lightBlue(`Publishing ${JSON.stringify(packageJson.name)}`));
 					console.log(lightBlue('Publishing files'));
 					console.log(fileSizes.map(({ file, size }) => `${file} ${dim(byteSize(size).toString())}`).join('\n'));
 					console.log(`\n${lightBlue('Total size')}`, byteSize(totalSize).toString());

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,7 @@ const { stringify } = JSON;
 					);
 					const totalSize = fileSizes.reduce((accumulator, { size }) => accumulator + size, 0);
 
-					console.log(lightBlue(`Publishing ${JSON.stringify(packageJson.name)}`));
+					console.log(lightBlue(`Publishing ${packageJson.name}`));
 					console.log(fileSizes.map(({ file, size }) => `${file} ${dim(byteSize(size).toString())}`).join('\n'));
 					console.log(`\n${lightBlue('Total size')}`, byteSize(totalSize).toString());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,6 +256,9 @@ const { stringify } = JSON;
 					console.log(fileSizes.map(({ file, size }) => `${file} ${dim(byteSize(size).toString())}`).join('\n'));
 					console.log(`\n${lightBlue('Total size')}`, byteSize(totalSize).toString());
 
+
+					console.log(fileSizes);
+					
 					return;
 					await spawn('git', ['add', '-f', ...publishFiles], { cwd: worktreePath });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,6 +271,7 @@ const { stringify } = JSON;
 					console.log(`\n${lightBlue('Total size')}`, byteSize(totalSize).toString());
 
 					if (gitSubdirectory) {
+						// Move files to the root of the git project
 						await Promise.all(
 							publishFiles.map(async (file) => {
 								const sourceFile = path.join(workingDirectory, file);

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,7 +276,6 @@ const { stringify } = JSON;
 					const totalSize = fileSizes.reduce((accumulator, { size }) => accumulator + size, 0);
 
 					console.log(lightBlue(`Publishing ${JSON.stringify(packageJson.name)}`));
-					console.log(lightBlue('Publishing files'));
 					console.log(fileSizes.map(({ file, size }) => `${file} ${dim(byteSize(size).toString())}`).join('\n'));
 					console.log(`\n${lightBlue('Total size')}`, byteSize(totalSize).toString());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,10 @@ const { stringify } = JSON;
 
 	await assertCleanTree();
 
+	// git rev-parse --show-prefix
+	const subdirectory = await simpleSpawn('git', ['rev-parse', '--show-prefix']);
+	console.log({ subdirectory });
+	
 	const currentBranch = await getCurrentBranchOrTagName();
 	const currentBranchSha = await getCurrentCommit();
 	const packageJsonPath = 'package.json';

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,10 +60,7 @@ const { stringify } = JSON;
 
 	await assertCleanTree();
 
-	// git rev-parse --show-prefix
-	const subdirectory = await simpleSpawn('git', ['rev-parse', '--show-prefix']);
-	console.log({ subdirectory });
-	
+	const gitSubdirectory = await simpleSpawn('git', ['rev-parse', '--show-prefix']);
 	const currentBranch = await getCurrentBranchOrTagName();
 	const currentBranchSha = await getCurrentCommit();
 	const packageJsonPath = 'package.json';
@@ -96,7 +93,9 @@ const { stringify } = JSON;
 			}
 
 			const localTemporaryBranch = `git-publish-${Date.now()}-${process.pid}`;
-			const workDirectory = path.join(os.tmpdir(), localTemporaryBranch);
+			const worktreePath = path.join(os.tmpdir(), localTemporaryBranch);
+			const workingDirectory = path.join(worktreePath, gitSubdirectory);
+
 			let success = false;
 
 			let remoteUrl;
@@ -116,7 +115,7 @@ const { stringify } = JSON;
 
 				// TODO: maybe delete all worktrees starting with `git-publish-`?
 
-				await spawn('git', ['worktree', 'add', '--force', workDirectory, 'HEAD']);
+				await spawn('git', ['worktree', 'add', '--force', worktreePath, 'HEAD']);
 			});
 
 			if (!dry) {
@@ -130,7 +129,7 @@ const { stringify } = JSON;
 						return;
 					}
 
-					await fs.symlink(path.resolve('node_modules'), path.join(workDirectory, 'node_modules'), 'dir');
+					await fs.symlink(path.resolve('node_modules'), path.join(workingDirectory, 'node_modules'), 'dir');
 
 					let orphan = false;
 					if (fresh) {
@@ -141,7 +140,7 @@ const { stringify } = JSON;
 							'--depth=1',
 							remote,
 							`${publishBranch}:${localTemporaryBranch}`,
-						], { cwd: workDirectory }).catch(error => error as SubprocessError);
+						], { cwd: worktreePath }).catch(error => error as SubprocessError);
 
 						// If fetch fails, remote branch doesnt exist yet, so fallback to orphan
 						orphan = 'exitCode' in fetchResult;
@@ -149,14 +148,14 @@ const { stringify } = JSON;
 
 					if (orphan) {
 						// Fresh orphan branch with no history
-						await spawn('git', ['checkout', '--orphan', localTemporaryBranch], { cwd: workDirectory });
+						await spawn('git', ['checkout', '--orphan', localTemporaryBranch], { cwd: worktreePath });
 					} else {
 						// Repoint HEAD to the fetched branch without checkout
-						await spawn('git', ['symbolic-ref', 'HEAD', `refs/heads/${localTemporaryBranch}`], { cwd: workDirectory });
+						await spawn('git', ['symbolic-ref', 'HEAD', `refs/heads/${localTemporaryBranch}`], { cwd: worktreePath });
 					}
 
 					// Remove all tracked files from index
-					await spawn('git', ['rm', '--cached', '-r', ':/'], { cwd: workDirectory });
+					await spawn('git', ['rm', '--cached', '-r', ':/'], { cwd: worktreePath });
 				});
 
 				if (!dry) {
@@ -171,17 +170,15 @@ const { stringify } = JSON;
 
 					// Using the deteced package manager might add packageManager to package.json
 					setTitle('Running hook "prepare"');
-					await spawn('npm', ['run', '--if-present', 'prepare'].filter(Boolean), { cwd: workDirectory });
+					await spawn('npm', ['run', '--if-present', 'prepare'].filter(Boolean), { cwd: workingDirectory });
 
 					setTitle('Running hook "prepack"');
-					await spawn('npm', ['run', '--if-present', 'prepack'].filter(Boolean), { cwd: workDirectory });
+					await spawn('npm', ['run', '--if-present', 'prepack'].filter(Boolean), { cwd: workingDirectory });
 				});
 
 				if (!dry) {
 					runHooks.clear();
 				}
-
-				const workTreePackageJsonPath = path.join(workDirectory, packageJsonPath);
 
 				const removeHooks = await task('Removing "prepare" & "prepack" hooks', async ({ setWarning }) => {
 					if (dry) {
@@ -223,7 +220,7 @@ const { stringify } = JSON;
 
 					if (mutated) {
 						await fs.writeFile(
-							workTreePackageJsonPath,
+							path.join(workingDirectory, packageJsonPath),
 							stringify(packageJson, null, 2),
 						);
 					}
@@ -239,17 +236,14 @@ const { stringify } = JSON;
 						return;
 					}
 
-					const publishFiles = await getNpmPacklist(
-						workDirectory,
-						packageJson,
-					);
+					const publishFiles = await getNpmPacklist(workingDirectory, packageJson);
 					if (publishFiles.length === 0) {
 						throw new Error('No publish files found');
 					}
 
 					const fileSizes = await Promise.all(
 						publishFiles.map(async (file) => {
-							const { size } = await fs.stat(path.join(workDirectory, file));
+							const { size } = await fs.stat(path.join(workingDirectory, file));
 							return {
 								file,
 								size,
@@ -262,9 +256,10 @@ const { stringify } = JSON;
 					console.log(fileSizes.map(({ file, size }) => `${file} ${dim(byteSize(size).toString())}`).join('\n'));
 					console.log(`\n${lightBlue('Total size')}`, byteSize(totalSize).toString());
 
-					await spawn('git', ['add', '-f', ...publishFiles], { cwd: workDirectory });
+					return;
+					await spawn('git', ['add', '-f', ...publishFiles], { cwd: worktreePath });
 
-					const trackedFiles = await gitStatusTracked({ cwd: workDirectory });
+					const trackedFiles = await gitStatusTracked({ cwd: worktreePath });
 					if (trackedFiles.length === 0) {
 						console.warn('⚠️  No new changes found to commit.');
 					} else {
@@ -286,17 +281,18 @@ const { stringify } = JSON;
 								commitMessage,
 								'--author=git-publish <bot@git-publish>',
 							],
-							{ cwd: workDirectory },
+							{ cwd: worktreePath },
 						);
 					}
 
-					commitSha = (await getCurrentCommit({ cwd: workDirectory }))!;
+					commitSha = (await getCurrentCommit({ cwd: worktreePath }))!;
 				});
 
 				if (!dry) {
 					commit.clear();
 				}
 
+				return;
 				const push = await task(
 					`Pushing branch ${stringify(publishBranch)} to remote ${stringify(remote)}`,
 					async ({ setWarning }) => {
@@ -311,7 +307,7 @@ const { stringify } = JSON;
 							'--no-verify',
 							remote,
 							`HEAD:${publishBranch}`,
-						], { cwd: workDirectory });
+						], { cwd: worktreePath });
 						success = true;
 					},
 				);
@@ -326,7 +322,7 @@ const { stringify } = JSON;
 						return;
 					}
 
-					await spawn('git', ['worktree', 'remove', '--force', workDirectory]);
+					await spawn('git', ['worktree', 'remove', '--force', worktreePath]);
 					await spawn('git', ['branch', '-D', localTemporaryBranch]);
 				});
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,8 +1,8 @@
+import path from 'node:path';
 import { describe, expect } from 'manten';
 import { createFixture } from 'fs-fixture';
 import { createGit, gitWorktree } from './utils/create-git.js';
 import { gitPublish } from './utils/git-publish.js';
-import path from 'node:path';
 
 describe('git-publish', ({ describe }) => {
 	describe('Error cases', ({ test }) => {
@@ -62,60 +62,60 @@ describe('git-publish', ({ describe }) => {
 	});
 
 	describe('Publish', ({ test }) => {
-		// test('preserves history', async ({ onTestFail }) => {
-		// 	const preBranch = 'develop';
+		test('preserves history', async ({ onTestFail }) => {
+			const preBranch = 'develop';
 
-		// 	const git = createGit(process.cwd());
-		// 	await git('fetch', ['origin', preBranch]);
-		// 	await using worktree = await gitWorktree(process.cwd(), preBranch);
+			const git = createGit(process.cwd());
+			await git('fetch', ['origin', preBranch]);
+			await using worktree = await gitWorktree(process.cwd(), preBranch);
 
-		// 	const gitPublishProcess = await gitPublish(worktree.path);
-		// 	onTestFail(() => {
-		// 		console.log(gitPublishProcess);
-		// 	});
+			const gitPublishProcess = await gitPublish(worktree.path);
+			onTestFail(() => {
+				console.log(gitPublishProcess);
+			});
 
-		// 	expect('exitCode' in gitPublishProcess).toBe(false);
-		// 	expect(gitPublishProcess.stdout).toMatch('✔');
+			expect('exitCode' in gitPublishProcess).toBe(false);
+			expect(gitPublishProcess.stdout).toMatch('✔');
 
-		// 	// The branch should remain unchanged
-		// 	const afterBranch = await worktree.git('branch', ['--show-current']);
-		// 	expect(afterBranch).toBe(preBranch);
+			// The branch should remain unchanged
+			const afterBranch = await worktree.git('branch', ['--show-current']);
+			expect(afterBranch).toBe(preBranch);
 
-		// 	// Assert that the published branch has multiple commits
-		// 	const publishedBranch = `npm/${preBranch}`;
-		// 	await worktree.git('fetch', ['--depth=2', 'origin', publishedBranch]);
-		// 	const commitCount = await worktree.git('rev-list', ['--count', `origin/${publishedBranch}`]);
-		// 	expect(Number(commitCount)).toBeGreaterThan(1);
-		// });
+			// Assert that the published branch has multiple commits
+			const publishedBranch = `npm/${preBranch}`;
+			await worktree.git('fetch', ['--depth=2', 'origin', publishedBranch]);
+			const commitCount = await worktree.git('rev-list', ['--count', `origin/${publishedBranch}`]);
+			expect(Number(commitCount)).toBeGreaterThan(1);
+		});
 
-		// test('--fresh', async ({ onTestFail }) => {
-		// 	const preBranch = 'master';
+		test('--fresh', async ({ onTestFail }) => {
+			const preBranch = 'master';
 
-		// 	const git = createGit(process.cwd());
-		// 	await git('fetch', ['origin', preBranch]);
-		// 	await using worktree = await gitWorktree(process.cwd(), preBranch);
+			const git = createGit(process.cwd());
+			await git('fetch', ['origin', preBranch]);
+			await using worktree = await gitWorktree(process.cwd(), preBranch);
 
-		// 	const gitPublishProcess = await gitPublish(worktree.path, ['--fresh']);
-		// 	onTestFail(() => {
-		// 		console.log(gitPublishProcess);
-		// 	});
+			const gitPublishProcess = await gitPublish(worktree.path, ['--fresh']);
+			onTestFail(() => {
+				console.log(gitPublishProcess);
+			});
 
-		// 	expect('exitCode' in gitPublishProcess).toBe(false);
-		// 	expect(gitPublishProcess.stdout).toMatch('✔');
+			expect('exitCode' in gitPublishProcess).toBe(false);
+			expect(gitPublishProcess.stdout).toMatch('✔');
 
-		// 	// The branch should remain unchanged
-		// 	const afterBranch = await worktree.git('branch', ['--show-current']);
-		// 	expect(afterBranch).toBe(preBranch);
+			// The branch should remain unchanged
+			const afterBranch = await worktree.git('branch', ['--show-current']);
+			expect(afterBranch).toBe(preBranch);
 
-		// 	// Published branch should include the development commit
-		// 	const publishedBranch = `npm/${preBranch}`;
-		// 	await worktree.git('fetch', ['--depth=2', 'origin', publishedBranch]);
-		// 	const commitCount = await worktree.git('rev-list', ['--count', `origin/${publishedBranch}`]);
-		// 	expect(Number(commitCount)).toBe(1);
-		// });
+			// Published branch should include the development commit
+			const publishedBranch = `npm/${preBranch}`;
+			await worktree.git('fetch', ['--depth=2', 'origin', publishedBranch]);
+			const commitCount = await worktree.git('rev-list', ['--count', `origin/${publishedBranch}`]);
+			expect(Number(commitCount)).toBe(1);
+		});
 
 		test('monorepo package', async ({ onTestFail }) => {
-			const preBranch = 'monorepo'; // change to develop later
+			const preBranch = 'monorepo'; // create actual test branches later
 
 			const git = createGit(process.cwd());
 			await git('fetch', ['origin', preBranch]);
@@ -139,6 +139,13 @@ describe('git-publish', ({ describe }) => {
 			await worktree.git('fetch', ['--depth=2', 'origin', publishedBranch]);
 			const commitCount = await worktree.git('rev-list', ['--count', `origin/${publishedBranch}`]);
 			expect(Number(commitCount)).toBe(1);
+
+			const filesInTreeString = await worktree.git('ls-tree', ['-r', '--name-only', `origin/${publishedBranch}`]);
+			const filesInTree = filesInTreeString.split('\n').filter(Boolean).sort();
+			expect(filesInTree).toEqual([
+				'dist/index.js',
+				'package.json',
+			]);
 		});
 	});
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,8 +1,14 @@
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { describe, expect } from 'manten';
 import { createFixture } from 'fs-fixture';
 import { createGit, gitWorktree } from './utils/create-git.js';
 import { gitPublish } from './utils/git-publish.js';
+
+const readJson = async (filePath: string) => {
+	const content = await fs.readFile(filePath, 'utf8');
+	return JSON.parse(content);
+};
 
 describe('git-publish', ({ describe }) => {
 	describe('Error cases', ({ test }) => {
@@ -135,7 +141,8 @@ describe('git-publish', ({ describe }) => {
 			expect(afterBranch).toBe(preBranch);
 
 			// Published branch should include the development commit
-			const publishedBranch = `npm/${preBranch}`;
+			const { name } = await readJson(path.join(monorepoPackagePath, 'package.json'));
+			const publishedBranch = `npm/${preBranch}-${name}`;
 			await worktree.git('fetch', ['--depth=2', 'origin', publishedBranch]);
 			const commitCount = await worktree.git('rev-list', ['--count', `origin/${publishedBranch}`]);
 			expect(Number(commitCount)).toBe(1);

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -2,6 +2,7 @@ import { describe, expect } from 'manten';
 import { createFixture } from 'fs-fixture';
 import { createGit, gitWorktree } from './utils/create-git.js';
 import { gitPublish } from './utils/git-publish.js';
+import path from 'node:path';
 
 describe('git-publish', ({ describe }) => {
 	describe('Error cases', ({ test }) => {
@@ -61,40 +62,67 @@ describe('git-publish', ({ describe }) => {
 	});
 
 	describe('Publish', ({ test }) => {
-		test('preserves history', async ({ onTestFail }) => {
-			const preBranch = 'develop';
+		// test('preserves history', async ({ onTestFail }) => {
+		// 	const preBranch = 'develop';
+
+		// 	const git = createGit(process.cwd());
+		// 	await git('fetch', ['origin', preBranch]);
+		// 	await using worktree = await gitWorktree(process.cwd(), preBranch);
+
+		// 	const gitPublishProcess = await gitPublish(worktree.path);
+		// 	onTestFail(() => {
+		// 		console.log(gitPublishProcess);
+		// 	});
+
+		// 	expect('exitCode' in gitPublishProcess).toBe(false);
+		// 	expect(gitPublishProcess.stdout).toMatch('✔');
+
+		// 	// The branch should remain unchanged
+		// 	const afterBranch = await worktree.git('branch', ['--show-current']);
+		// 	expect(afterBranch).toBe(preBranch);
+
+		// 	// Assert that the published branch has multiple commits
+		// 	const publishedBranch = `npm/${preBranch}`;
+		// 	await worktree.git('fetch', ['--depth=2', 'origin', publishedBranch]);
+		// 	const commitCount = await worktree.git('rev-list', ['--count', `origin/${publishedBranch}`]);
+		// 	expect(Number(commitCount)).toBeGreaterThan(1);
+		// });
+
+		// test('--fresh', async ({ onTestFail }) => {
+		// 	const preBranch = 'master';
+
+		// 	const git = createGit(process.cwd());
+		// 	await git('fetch', ['origin', preBranch]);
+		// 	await using worktree = await gitWorktree(process.cwd(), preBranch);
+
+		// 	const gitPublishProcess = await gitPublish(worktree.path, ['--fresh']);
+		// 	onTestFail(() => {
+		// 		console.log(gitPublishProcess);
+		// 	});
+
+		// 	expect('exitCode' in gitPublishProcess).toBe(false);
+		// 	expect(gitPublishProcess.stdout).toMatch('✔');
+
+		// 	// The branch should remain unchanged
+		// 	const afterBranch = await worktree.git('branch', ['--show-current']);
+		// 	expect(afterBranch).toBe(preBranch);
+
+		// 	// Published branch should include the development commit
+		// 	const publishedBranch = `npm/${preBranch}`;
+		// 	await worktree.git('fetch', ['--depth=2', 'origin', publishedBranch]);
+		// 	const commitCount = await worktree.git('rev-list', ['--count', `origin/${publishedBranch}`]);
+		// 	expect(Number(commitCount)).toBe(1);
+		// });
+
+		test('monorepo package', async ({ onTestFail }) => {
+			const preBranch = 'monorepo'; // change to develop later
 
 			const git = createGit(process.cwd());
 			await git('fetch', ['origin', preBranch]);
 			await using worktree = await gitWorktree(process.cwd(), preBranch);
 
-			const gitPublishProcess = await gitPublish(worktree.path);
-			onTestFail(() => {
-				console.log(gitPublishProcess);
-			});
-
-			expect('exitCode' in gitPublishProcess).toBe(false);
-			expect(gitPublishProcess.stdout).toMatch('✔');
-
-			// The branch should remain unchanged
-			const afterBranch = await worktree.git('branch', ['--show-current']);
-			expect(afterBranch).toBe(preBranch);
-
-			// Assert that the published branch has multiple commits
-			const publishedBranch = `npm/${preBranch}`;
-			await worktree.git('fetch', ['--depth=2', 'origin', publishedBranch]);
-			const commitCount = await worktree.git('rev-list', ['--count', `origin/${publishedBranch}`]);
-			expect(Number(commitCount)).toBeGreaterThan(1);
-		});
-
-		test('--fresh', async ({ onTestFail }) => {
-			const preBranch = 'master';
-
-			const git = createGit(process.cwd());
-			await git('fetch', ['origin', preBranch]);
-			await using worktree = await gitWorktree(process.cwd(), preBranch);
-
-			const gitPublishProcess = await gitPublish(worktree.path, ['--fresh']);
+			const monorepoPackagePath = path.join(worktree.path, 'tests/monorepo-fixture');
+			const gitPublishProcess = await gitPublish(monorepoPackagePath, ['--fresh']);
 			onTestFail(() => {
 				console.log(gitPublishProcess);
 			});

--- a/tests/monorepo-fixture/dist/index.js
+++ b/tests/monorepo-fixture/dist/index.js
@@ -1,0 +1,1 @@
+console.log('hello world');

--- a/tests/monorepo-fixture/index.js
+++ b/tests/monorepo-fixture/index.js
@@ -1,0 +1,1 @@
+console.log('hello world');

--- a/tests/monorepo-fixture/index.js
+++ b/tests/monorepo-fixture/index.js
@@ -1,1 +1,0 @@
-console.log('hello world');

--- a/tests/monorepo-fixture/package.json
+++ b/tests/monorepo-fixture/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "test-pkg",
+    "version": "0.0.0"
+}

--- a/tests/monorepo-fixture/package.json
+++ b/tests/monorepo-fixture/package.json
@@ -1,4 +1,4 @@
 {
-    "name": "test-pkg",
-    "version": "0.0.0"
+	"name": "test-pkg",
+	"version": "0.0.0"
 }

--- a/tests/monorepo-fixture/package.json
+++ b/tests/monorepo-fixture/package.json
@@ -1,4 +1,4 @@
 {
-	"name": "test-pkg",
+	"name": "@org/test-pkg",
 	"version": "0.0.0"
 }


### PR DESCRIPTION
This adds initial support for publishing packages from monorepos. It works by publishing the contents of a subdirectory to the root of a Git project.

However, this is only a first step. It does not handle things like resolving `workspace:` dependencies in `package.json`, which are essential for full monorepo compatibility.

In the future, we'll likely switch to running the appropriate package manager's `pack` command. This would let us properly resolve `workspace:` references and leverage built-in monorepo features. While this adds the overhead of packing and unpacking, it's the most accurate and maintainable approach—avoiding the need to reimplement monorepo logic ourselves.


closes https://github.com/privatenumber/git-publish/issues/3
closes https://github.com/privatenumber/git-publish/pull/10