### PR TITLE
fix: add bun.lock support

### DIFF
--- a/src/utils/detect-package-manager.ts
+++ b/src/utils/detect-package-manager.ts
@@ -5,6 +5,7 @@ export const detectPackageManager = () => Promise.any([
 	fs.access('yarn.lock').then(() => 'yarn' as const),
 	fs.access('pnpm-lock.yaml').then(() => 'pnpm' as const),
 	fs.access('bun.lockb').then(() => 'bun' as const),
+	fs.access('bun.lock').then(() => 'bun' as const),
 ]).catch(
 	() => 'npm' as const, // If no lock files are found, default to npm
 );


### PR DESCRIPTION
bun supports both `bun.lockb` and `bun.lock` 